### PR TITLE
Switch to shared-modules version of fluidsynth2 module

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Boxtron.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Boxtron.yml
@@ -48,14 +48,7 @@ modules:
 
       - shared-modules/glu/glu-9.json
 
-      - name: fluidsynth
-        buildsystem: cmake-ninja
-        config-opts:
-          - -DLIB_SUFFIX=
-        sources:
-          - type: archive
-            url: https://github.com/FluidSynth/fluidsynth/archive/v2.1.0.tar.gz
-            sha256: 526addc6d8445035840d3af7282d3ba89567df209d28e183da04a1a877da2da3
+      - shared-modules/linux-audio/fluidsynth2.json
 
       - name: munt
         buildsystem: cmake-ninja


### PR DESCRIPTION
`fluidsynth2` [available](https://github.com/flathub/shared-modules/blob/master/linux-audio/fluidsynth2.json) now in `shared-modules`. Would be nice to switch on this version. Thanks.